### PR TITLE
Add support for Razor Pages and custom endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ dotnet add package Edi.RouteDebugger
 
 > Recommend use in development environment ONLY
 
+> If you are using the Developer Exception Page middleware, put this middleware BEFORE the call to `app.UseDeveloperExceptionPage()` as the exception page would not work otherwise.
+
 ```csharp
 if (env.IsDevelopment())
 {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ if (env.IsDevelopment())
 }
 ```
 
+You can also use an overload to specify custom path where the route debugger will be available, for example:
+
+```csharp
+if (env.IsDevelopment())
+{
+    app.UseRouteDebugger("/tools/route-debugger");
+}
+```
+
 ### View Current Route
 
 - Open any page in your application
@@ -44,6 +53,6 @@ if (env.IsDevelopment())
 
 ### View All Routes
 
-- Access ```/route-debugger``` from browser or postman
+- Access `/route-debugger` or your custom path from browser or postman
 
 ![](https://raw.githubusercontent.com/EdiWang/AspNetCore-RouteDebuggerMiddleware/master/screenshot/Screenshot_2.png)

--- a/src/Edi.RouteDebugger/Edi.RouteDebugger.csproj
+++ b/src/Edi.RouteDebugger/Edi.RouteDebugger.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/EdiWang/AspNetCore-RouteDebuggerMiddleware</PackageProjectUrl>
-    <PackageTags>ASP.NET Core, .NET Core, Route, MVC, Endpoint</PackageTags>
+    <PackageTags>ASP.NET Core, .NET Core, Route, MVC, Razor Pages, Endpoint</PackageTags>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/src/Edi.RouteDebugger/RouteDebuggerExtensions.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerExtensions.cs
@@ -5,10 +5,9 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class RouteDebuggerExtensions
     {
-        public static IApplicationBuilder UseRouteDebugger(this IApplicationBuilder app)
+        public static IApplicationBuilder UseRouteDebugger(this IApplicationBuilder app, string path = "/route-debugger")
         {
-            app.UseMiddleware<RouteDebuggerMiddleware>();
-            return app;
+            return app.UseMiddleware<RouteDebuggerMiddleware>(path);
         }
     }
 }

--- a/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -28,6 +28,7 @@ namespace Edi.RouteDebugger
                     {
                         Action = x.RouteValues["Action"],
                         Controller = x.RouteValues["Controller"],
+                        Page = x.RouteValues["Page"],
                         x.AttributeRouteInfo?.Name,
                         x.AttributeRouteInfo?.Template,
                         Contraint = x.ActionConstraints

--- a/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
@@ -60,7 +60,8 @@ namespace Edi.RouteDebugger
             await _next(context);
 
             context.Response.Body.Seek(0, SeekOrigin.Begin);
-            await new StreamReader(context.Response.Body).ReadToEndAsync();
+            using var streamReader = new StreamReader(context.Response.Body);
+            await streamReader.ReadToEndAsync();
             context.Response.Body.Seek(0, SeekOrigin.Begin);
 
             var routeData = context.GetRouteData();

--- a/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
@@ -18,7 +18,7 @@ namespace Edi.RouteDebugger
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context, IActionDescriptorCollectionProvider provider = null)
+        public Task Invoke(HttpContext context, IActionDescriptorCollectionProvider provider = null)
         {
             if (context.Request.Path == "/route-debugger")
             {
@@ -37,16 +37,16 @@ namespace Edi.RouteDebugger
                     var routesJson = JsonSerializer.Serialize(routes);
 
                     context.Response.ContentType = "application/json";
-                    await context.Response.WriteAsync(routesJson, Encoding.UTF8);
+                    return context.Response.WriteAsync(routesJson, Encoding.UTF8);
                 }
                 else
                 {
-                    await context.Response.WriteAsync("IActionDescriptorCollectionProvider is null", Encoding.UTF8);
+                    return context.Response.WriteAsync("IActionDescriptorCollectionProvider is null", Encoding.UTF8);
                 }
             }
             else
             {
-                await SetCurrentRouteInfo(context);
+                return SetCurrentRouteInfo(context);
             }
         }
 

--- a/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
@@ -12,15 +12,17 @@ namespace Edi.RouteDebugger
     public class RouteDebuggerMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly string _path;
 
-        public RouteDebuggerMiddleware(RequestDelegate next)
+        public RouteDebuggerMiddleware(RequestDelegate next, string path)
         {
             _next = next;
+            _path = path;
         }
 
         public Task Invoke(HttpContext context, IActionDescriptorCollectionProvider provider = null)
         {
-            if (context.Request.Path == "/route-debugger")
+            if (context.Request.Path == _path)
             {
                 if (null != provider)
                 {

--- a/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
+++ b/src/Edi.RouteDebugger/RouteDebuggerMiddleware.cs
@@ -34,7 +34,7 @@ namespace Edi.RouteDebugger
                         Contraint = x.ActionConstraints
                     }).ToArray();
 
-                    var routesJson = JsonSerializer.Serialize(routes);
+                    var routesJson = JsonSerializer.Serialize(routes, new JsonSerializerOptions() { WriteIndented = true });
 
                     context.Response.ContentType = "application/json";
                     return context.Response.WriteAsync(routesJson, Encoding.UTF8);

--- a/src/SampleWebApp/Pages/RazorPage.cshtml
+++ b/src/SampleWebApp/Pages/RazorPage.cshtml
@@ -2,3 +2,5 @@
 @model SampleWebApp.Pages.RazorPageModel
 @{
 }
+
+<h1>RazorPage</h1>

--- a/src/SampleWebApp/Pages/RazorPage.cshtml
+++ b/src/SampleWebApp/Pages/RazorPage.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model SampleWebApp.Pages.RazorPageModel
+@{
+}

--- a/src/SampleWebApp/Pages/RazorPage.cshtml.cs
+++ b/src/SampleWebApp/Pages/RazorPage.cshtml.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SampleWebApp.Pages
+{
+    public class RazorPageModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml
+++ b/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml
@@ -1,0 +1,4 @@
+﻿@page "/razor-page"
+@model SampleWebApp.Pages.RazorPageWithRouteModel
+@{
+}

--- a/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml
+++ b/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml
@@ -2,3 +2,5 @@
 @model SampleWebApp.Pages.RazorPageWithRouteModel
 @{
 }
+
+<h1>RazorPageWithRoute</h1>

--- a/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml.cs
+++ b/src/SampleWebApp/Pages/RazorPageWithRoute.cshtml.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SampleWebApp.Pages
+{
+    public class RazorPageWithRouteModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/src/SampleWebApp/Startup.cs
+++ b/src/SampleWebApp/Startup.cs
@@ -18,6 +18,7 @@ namespace SampleWebApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddRazorPages();
             services.AddControllersWithViews();
         }
 
@@ -44,6 +45,7 @@ namespace SampleWebApp
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapRazorPages();
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");

--- a/src/SampleWebApp/Views/Shared/_Layout.cshtml
+++ b/src/SampleWebApp/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - SampleWebApp</title>
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
     <link rel="stylesheet" href="~/css/site.css" />
 </head>
 <body>


### PR DESCRIPTION
I noticed that this lib, while it does work with Razor Pages and shows their routes, it does not show the real page name (view engine path) compared to Controller and Action being shown for Action methods. So I added a new entry to the JSON that shows the page name.

I also added support for custom endpoint path, so users can use something else than the default `/route-debugger`.

Some other minor improvements:
- removed unnecessary async-await
- made the `StreamReader` dispose
- added link to Bootstrap CDN to the sample app as the link pointed to non-existing files and the page looked unnecessarily ugly
- made the JSON output be indented for better readability; on the screenshot I see that in Edge it probably is formatted by default, but Chrome outputs one unreadable auto-wrapped line so now it's readable even there :smile:
- I noticed that the Developer Exception Page does not work if registered earlier in the pipeline than this lib, so I added a note about it to the readme

PS: Cool profile picture 😎 