### PR TITLE
Refactor RouteDebuggerMiddleware and update usage path

### DIFF
--- a/src/Edi.RouteDebugger/Edi.RouteDebugger.csproj
+++ b/src/Edi.RouteDebugger/Edi.RouteDebugger.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <Authors>Edi Wang</Authors>
-    <Company>edi.wang</Company>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/EdiWang/AspNetCore-RouteDebuggerMiddleware</PackageProjectUrl>
-    <PackageTags>ASP.NET Core, .NET Core, Route, MVC, Razor Pages, Endpoint</PackageTags>
-    <Description>Show current route info and all routes in an ASP.NET Core application</Description>
-    <Version>1.11.0</Version>
-    <PackageIcon>edi-logo-blue.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<Nullable>enable</Nullable>
+		<Authors>Edi Wang</Authors>
+		<Company>edi.wang</Company>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/EdiWang/AspNetCore-RouteDebuggerMiddleware</PackageProjectUrl>
+		<PackageTags>ASP.NET Core, .NET Core, Route, MVC, Razor Pages, Endpoint</PackageTags>
+		<Description>Show current route info and all routes in an ASP.NET Core application</Description>
+		<Version>1.12.0</Version>
+		<PackageIcon>edi-logo-blue.png</PackageIcon>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <None Include="..\..\img\edi-logo-blue.png" Pack="true" PackagePath="\"/>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\..\img\edi-logo-blue.png" Pack="true" PackagePath="\"/>
+	</ItemGroup>
 </Project>

--- a/src/SampleWebApp/Program.cs
+++ b/src/SampleWebApp/Program.cs
@@ -8,7 +8,7 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseRouteDebugger();
+    app.UseRouteDebugger("/tools/route-debugger");
 }
 
 // Test for #3


### PR DESCRIPTION
Refactored RouteDebuggerMiddleware for improved nullability and code clarity, splitting route list and current route info handling into separate methods. Updated the sample app to use a custom route debugger path and incremented package version to 1.12.0.